### PR TITLE
Improve login mode detection and hint

### DIFF
--- a/datasage-frontend/src/components/AuthModal.css
+++ b/datasage-frontend/src/components/AuthModal.css
@@ -113,6 +113,7 @@
 }
 .auth-error { color: #d63031; font-size: 0.97rem; margin-top: -0.7rem; }
 .auth-info { color: #0096c7; font-size: 0.98rem; margin-top: -0.7rem; }
+.auth-hint { color: #555; font-size: 0.97rem; margin-top: -0.7rem; }
 .mode-btn {
   border: 1px solid #e5e7ef;
   background: #f7fafd;

--- a/datasage-frontend/src/components/AuthModal.jsx
+++ b/datasage-frontend/src/components/AuthModal.jsx
@@ -41,7 +41,7 @@ export default function AuthModal({ open, onClose, onLogin, defaultTab = "login"
     password: "",
     loginOtp: "",
     loginCountry: "+91",
-    loginMode: "password", // or "otp"
+    loginMode: "", // will be set to 'otp' or 'password' when valid
     phone: "",
     signupCountry: "+91",
     otp: "",
@@ -69,7 +69,7 @@ export default function AuthModal({ open, onClose, onLogin, defaultTab = "login"
         password: "",
         loginOtp: "",
         loginCountry: "+91",
-        loginMode: "password",
+        loginMode: "",
         phone: "",
         signupCountry: "+91",
         otp: "",
@@ -93,7 +93,7 @@ export default function AuthModal({ open, onClose, onLogin, defaultTab = "login"
   }, [open, tab, defaultTab]);
 
   // ---- HELPERS ----
-  const isPhone = (v) => /^\d{7,}$/.test(v.replace(/\D/g, "")); // crude, basic
+  const isPhone = (v) => /^\d{10,}$/.test(v.replace(/\D/g, "")); // require full length
   const isEmail = (v) => /\S+@\S+\.\S+/.test(v);
 
   // ---- INPUT CHANGE ----
@@ -102,7 +102,13 @@ export default function AuthModal({ open, onClose, onLogin, defaultTab = "login"
     setForm((f) => {
       const updated = { ...f, [name]: value };
       if (name === "loginId") {
-        updated.loginMode = isPhone(value) ? "otp" : "password";
+        if (isPhone(value)) {
+          updated.loginMode = "otp";
+        } else if (isEmail(value)) {
+          updated.loginMode = "password";
+        } else {
+          updated.loginMode = "";
+        }
       }
       return updated;
     });
@@ -397,7 +403,13 @@ export default function AuthModal({ open, onClose, onLogin, defaultTab = "login"
               </select>
               <input
                 name="loginId"
-                placeholder="Phone Number or Email"
+                placeholder={
+                  form.loginMode === "otp"
+                    ? "Phone Number"
+                    : form.loginMode === "password"
+                    ? "Email"
+                    : "Phone Number or Email"
+                }
                 className="auth-input"
                 value={form.loginId}
                 onChange={handleChange}
@@ -405,6 +417,9 @@ export default function AuthModal({ open, onClose, onLogin, defaultTab = "login"
                 style={{ flex: 1 }}
               />
             </div>
+            {!form.loginMode && (
+              <div className="auth-hint">Enter phone for OTP or email for password</div>
+            )}
             {/* Password field only for email login */}
             {form.loginMode === "password" && (
               <input
@@ -430,7 +445,11 @@ export default function AuthModal({ open, onClose, onLogin, defaultTab = "login"
             )}
             {errors.loginId && <div className="auth-error">{errors.loginId}</div>}
             <button className="auth-btn" type="submit" disabled={loading}>
-              {form.loginMode === "otp" ? "Send OTP" : "Login"}
+              {form.loginMode === "otp"
+                ? "Send OTP"
+                : form.loginMode === "password"
+                ? "Login"
+                : "Continue"}
             </button>
             <div className="auth-divider">or continue with</div>
             <div className="auth-socials">


### PR DESCRIPTION
## Summary
- refine phone detection with full length requirement
- keep `loginMode` empty until a valid phone number or email is entered
- show a hint when login mode is undetermined
- adapt login placeholder and button text
- add styling for hint messages

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` in `datasage-frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ea97a05fc8324b7633655bd91b88d